### PR TITLE
Pre release

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,9 @@
+R4.12.1    02-24-2025    Kukhee Kim (khkim)
+                         - build NC mode XTCAV database template with Bsa.db
+                           to align the internal bsa record name to BSSS PV name in SC mode
+                           (allowing use bsa recrod as BSSS equivalent, requested by Tim Maxwell
+                            in an email discussion jan 21, 2025)
+
 R4.12.0    09-20-2024    Kukhee Kim (khkim)
                          - adjust BSA data channels "per destinaiton"
                          - dropping all of input channel based BSA data channels

--- a/llrfHlsAsynApp/Db/llrfHlsAsyn_NC_XTCAV.substitutions
+++ b/llrfHlsAsynApp/Db/llrfHlsAsyn_NC_XTCAV.substitutions
@@ -202,7 +202,7 @@ file fastPV.db
 
 
 
-file Bsa2.db
+file Bsa.db
 {
   pattern {  DEVICE      ,  ATRB             , LNK      ,  EGU     ,  HOPR,  LOPR  }
           { "$(DEVHXR)"  , "PACT"            , ""       , "degrees", "180.", "-180."}


### PR DESCRIPTION
                         - build NC mode XTCAV database template with Bsa.db
                           to align the internal bsa record name to BSSS PV name in SC mode
                           (allowing use bsa recrod as BSSS equivalent, requested by Tim Maxwell
                            in an email discussion jan 21, 2025)